### PR TITLE
Customization of Headers, Cookies and Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,42 @@ Autoconfigured `WebClient` instances are the result of calling Spring Boot autoc
 
 If for any reason you cannot rely on the autoconfigured `WebClient`, but you still want to use autoconfigured HTTP Interface based HTTP client, make sure to create a bean with name `<client-name>.WebClient`, which will be picked up to create an HTTP client.
 
+### Customizing Headers
+Default headers can be set in `application.yml` or `application.properties` under the prefix `http.clients.<client-name>.headers` key. 
+
+```yaml
+http.clients:
+  todo-client:
+    url: https://jsonplaceholder.typicode.com/todos
+    headers:
+      X-My-Header: my-value-x
+      Y-My-Header: ${DYNAMIC_VALUE:default-value}
+```
+
+### Customizing Cookies
+Default cookies can be set in `application.yml` or `application.properties` under the prefix `http.clients.<client-name>.cookies` key.
+
+```yaml
+http.clients:
+  todo-client:
+    url: https://jsonplaceholder.typicode.com/todos
+    cookies:
+      someCookie: cookie-value
+      someDynamicCookie: ${DYNAMIC_VALUE:default-value}
+```
+
+### Adding Filters
+[Filter functions](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/reactive/function/client/ExchangeFilterFunction.html) can be defined in `application.yml` or `application.properties` under the prefix `http.clients.<client-name>.filters` key.
+
+```yaml
+http.clients:
+  todo-client:
+    url: https://jsonplaceholder.typicode.com/todos
+    filters:
+      - filterFunction
+      - filterFunction2
+```
+
 ## 👥 Contributing
 
 If you found a bug or a missing feature - you're very welcome to submit an issue and a pull request with a fix.

--- a/example/src/main/java/app/App.java
+++ b/example/src/main/java/app/App.java
@@ -2,12 +2,25 @@ package app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import reactor.core.publisher.Mono;
 
 @SpringBootApplication
 public class App {
 
     public static void main(String[] args) {
         SpringApplication.run(App.class, args);
+    }
+
+    @Bean
+    ExchangeFilterFunction filterFunction(){
+        return ExchangeFilterFunction.ofRequestProcessor(
+                req -> Mono.just(ClientRequest.from(req)
+                        .header("header2", "value2")
+                        .build())
+        );
     }
 }
 

--- a/example/src/main/resources/application.yml
+++ b/example/src/main/resources/application.yml
@@ -2,4 +2,10 @@ http.clients:
   todo-client:
     url: https://jsonplaceholder.typicode.com/todos
   user-client:
-    url: https://jsonplaceholder.typicode.com/users
+    url: https://asdasdasd.free.beeceptor.com/users
+    headers:
+      header1: value1
+    cookies:
+      cookie1: value1
+    filters:
+      - filterFunction

--- a/spring-boot-http-clients/pom.xml
+++ b/spring-boot-http-clients/pom.xml
@@ -55,6 +55,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>provided</scope>

--- a/spring-boot-http-clients/src/main/java/com/maciejwalkowiak/spring/http/WebClientsProperties.java
+++ b/spring-boot-http-clients/src/main/java/com/maciejwalkowiak/spring/http/WebClientsProperties.java
@@ -1,5 +1,6 @@
 package com.maciejwalkowiak.spring.http;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -19,6 +20,12 @@ public class WebClientsProperties {
 
     public static class WebClientConfig {
         private String url;
+        
+        private List<String> filters;
+        
+        private Map<String, String> headers;
+
+        private Map<String, String> cookies;
 
         public String getUrl() {
             return url;
@@ -26,6 +33,30 @@ public class WebClientsProperties {
 
         public void setUrl(String url) {
             this.url = url;
+        }
+
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        public void setHeaders(Map<String, String> headers) {
+            this.headers = headers;
+        }
+
+        public List<String> getFilters() {
+            return filters;
+        }
+
+        public void setFilters(List<String> filters) {
+            this.filters = filters;
+        }
+
+        public Map<String, String> getCookies() {
+            return cookies;
+        }
+
+        public void setCookies(Map<String, String> cookies) {
+            this.cookies = cookies;
         }
     }
 }

--- a/spring-boot-http-clients/src/main/java/com/maciejwalkowiak/spring/http/registration/WebClientFactoryBean.java
+++ b/spring-boot-http-clients/src/main/java/com/maciejwalkowiak/spring/http/registration/WebClientFactoryBean.java
@@ -8,12 +8,16 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * Factory bean creating instances of {@link WebClient} from configuration provided through {@link WebClientsProperties}.
  *
  * @author Maciej Walkowiak
+ * @author Tigran Babloyan
  */
 public class WebClientFactoryBean  implements FactoryBean<Object>, ApplicationContextAware {
     @Nullable
@@ -36,10 +40,23 @@ public class WebClientFactoryBean  implements FactoryBean<Object>, ApplicationCo
 
         Assert.state(webClientConfig != null, "WebClient with name: " + name + " is not configured");
 
-        WebClient.Builder builder = applicationContext.getBean(WebClient.Builder.class);
+        WebClient.Builder builder = applicationContext.getBean(WebClient.Builder.class)
+                .baseUrl(webClientConfig.getUrl());
+        if(!CollectionUtils.isEmpty(webClientConfig.getFilters())){
+            webClientConfig.getFilters().stream()
+                    .map(filter -> applicationContext.getBean(filter, ExchangeFilterFunction.class))
+                    .forEach(builder::filter);
+        }
 
-        return builder.baseUrl(webClientConfig.getUrl())
-                .build();
+        if(!CollectionUtils.isEmpty(webClientConfig.getHeaders())){
+            webClientConfig.getHeaders().forEach(builder::defaultHeader);
+        }
+
+        if(!CollectionUtils.isEmpty(webClientConfig.getCookies())){
+            webClientConfig.getCookies().forEach(builder::defaultCookie);
+        }
+
+        return builder.build();
     }
 
     @Override

--- a/spring-boot-http-clients/src/main/java/com/maciejwalkowiak/spring/http/registration/WebClientsRegistrar.java
+++ b/spring-boot-http-clients/src/main/java/com/maciejwalkowiak/spring/http/registration/WebClientsRegistrar.java
@@ -1,9 +1,5 @@
 package com.maciejwalkowiak.spring.http.registration;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
-
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
@@ -16,10 +12,16 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Registers bean definitions for {@link WebClient}s defined in Spring {@link Environment} under prefix {@code "http.clients}.
  *
  * @author Maciej Walkowiak
+ * @author Tigran Babloyan
  */
 public class WebClientsRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
     private static final String PREFIX = "http.clients";
@@ -39,14 +41,14 @@ public class WebClientsRegistrar implements ImportBeanDefinitionRegistrar, Envir
         }
     }
 
-    private List<String> resolveClientNames() {
+    private Set<String> resolveClientNames() {
         ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
         return env.getPropertySources().stream()
                 .flatMap(WebClientsRegistrar::resolvePropertyNames)
                 .filter(it -> it.startsWith(PREFIX))
                 .map(it -> it.substring((PREFIX + ".").length()))
                 .map(it -> it.substring(0, it.indexOf(".")))
-                .toList();
+                .collect(Collectors.toSet());
     }
 
     private static Stream<String> resolvePropertyNames(PropertySource<?> it) {

--- a/spring-boot-http-clients/src/test/java/integration/IntegrationTest.java
+++ b/spring-boot-http-clients/src/test/java/integration/IntegrationTest.java
@@ -3,6 +3,12 @@ package integration;
 import com.maciejwalkowiak.spring.http.annotation.HttpClient;
 import com.maciejwalkowiak.spring.http.autoconfigure.HttpClientsAutoConfiguration;
 import com.maciejwalkowiak.spring.http.autoconfigure.WebClientsAutoConfiguration;
+import okhttp3.Cookie;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -10,8 +16,16 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.service.annotation.GetExchange;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,6 +33,22 @@ public class IntegrationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(HttpClientsAutoConfiguration.class, WebClientsAutoConfiguration.class, WebClientAutoConfiguration.class));
+
+    private MockWebServer server;
+
+
+    @BeforeEach
+    void setUp() {
+        this.server = new MockWebServer();
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @AfterEach
+    void shutdown() throws IOException {
+        if (this.server != null) {
+            this.server.shutdown();
+        }
+    }
 
     @Test
     void createsWebClientsFromProperties() {
@@ -28,10 +58,89 @@ public class IntegrationTest {
                 .run(ctx -> assertThat(ctx.getBean(TodoClient.class)).isNotNull());
     }
 
+    @Test
+    void createsWebClientsFromPropertiesWithHeaders() {
+        prepareResponse(response -> response.setResponseCode(200).setBody("Hello Http Clients!"));
+        String baseUrl = this.server.url("/").toString();
+        contextRunner
+                .withSystemProperties("dynamicHeader:dynamicHeaderValue")
+                .withConfiguration(UserConfigurations.of(AppConfigWithoutWebClientBean.class))
+                .withPropertyValues("http.clients.todo-client.url=%s".formatted(baseUrl),
+                        "http.clients.todo-client.headers.staticHeader=staticHeaderValue",
+                        "http.clients.todo-client.headers.dynamicHeader=${dynamicHeader}")
+                .run(ctx -> {
+                    TodoClient todoClient = ctx.getBean(TodoClient.class);
+                    todoClient.get();
+
+                    RecordedRequest request = this.server.takeRequest();
+                    assertThat(request.getHeaders().get("staticHeader")).isEqualTo("staticHeaderValue");
+                    assertThat(request.getHeaders().get("dynamicHeader")).isEqualTo("dynamicHeaderValue");
+                });
+    }
+
+    @Test
+    void createsWebClientsFromPropertiesWithCookies() {
+        prepareResponse(response -> response.setResponseCode(200).setBody("Hello Http Clients!"));
+        String baseUrl = this.server.url("/").toString();
+        contextRunner
+                .withSystemProperties("dynamicCookie:dynamicCookieValue")
+                .withConfiguration(UserConfigurations.of(AppConfigWithoutWebClientBean.class))
+                .withPropertyValues("http.clients.todo-client.url=%s".formatted(baseUrl),
+                        "http.clients.todo-client.cookies.staticCookie=staticCookieValue",
+                        "http.clients.todo-client.cookies.dynamicCookie=${dynamicCookie}")
+                .run(ctx -> {
+                    TodoClient todoClient = ctx.getBean(TodoClient.class);
+                    todoClient.get();
+
+                    RecordedRequest request = this.server.takeRequest();
+                    assertThat(request.getHeaders().get("Cookie")).isEqualTo("staticCookie=staticCookieValue;dynamicCookie=dynamicCookieValue");
+                });
+    }
+
+    @Test
+    void createsWebClientsFromPropertiesWithFilter() {
+        prepareResponse(response -> response.setResponseCode(200).setBody("Hello Http Clients!"));
+        String baseUrl = this.server.url("/").toString();
+        contextRunner
+                .withConfiguration(UserConfigurations.of(AppConfigWithoutWebClientBean.class))
+                .withPropertyValues("http.clients.todo-client.url=%s".formatted(baseUrl),
+                        "http.clients.todo-client.filters=filterFunction1,filterFunction2")
+                .run(ctx -> {
+                    TodoClient todoClient = ctx.getBean(TodoClient.class);
+                    todoClient.get();
+
+                    RecordedRequest request = this.server.takeRequest();
+                    assertThat(request.getHeaders().get("Function1")).isEqualTo("Function1");
+                    assertThat(request.getHeaders().get("Function2")).isEqualTo("Function2");
+                });
+    }
+
+    private void prepareResponse(Consumer<MockResponse> consumer) {
+        MockResponse response = new MockResponse();
+        consumer.accept(response);
+        this.server.enqueue(response);
+    }
+
     @Configuration
     @EnableAutoConfiguration
     static class AppConfigWithoutWebClientBean {
+        @Bean
+        ExchangeFilterFunction filterFunction1(){
+            return ExchangeFilterFunction.ofRequestProcessor(
+                    req -> Mono.just(ClientRequest.from(req)
+                            .header("Function1", "Function1")
+                            .build())
+            );
+        }
 
+        @Bean
+        ExchangeFilterFunction filterFunction2(){
+            return ExchangeFilterFunction.ofRequestProcessor(
+                    req -> Mono.just(ClientRequest.from(req)
+                            .header("Function2", "Function2")
+                            .build())
+            );
+        }
     }
 
     @HttpClient("todo-client")


### PR DESCRIPTION
This one adds the ability to customize the default cookies, headers, and filter functions.

Very helpful in case the Rest API requires some sort of Authorization via cookies and headers.

Simple bearer auth can be achieved via

```yaml
http.clients:
  todo-client:
    url: https://jsonplaceholder.typicode.com/todos
    headers:
      Authorization: Bearer ${sometoken}
```